### PR TITLE
use the resources api definition for the validation of resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ $RECYCLE.BIN/
 # Others
 lib/
 data/
+/db

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "mongoose": "^4.9.8",
     "request-promise-native": "^1.0.4",
     "serve-favicon": "^2.4.2",
-    "winston": "^2.3.1"
+    "winston": "^2.3.1",
+    "@schul-cloud/schul-cloud-resources-api-v1" : "1.0.2"
   },
   "devDependencies": {
     "eslint": "^3.19.0",

--- a/src/hooks/validate-resource-schema/index.js
+++ b/src/hooks/validate-resource-schema/index.js
@@ -1,30 +1,10 @@
 const commonHooks = require('feathers-hooks-common');
-const Ajv         = require('ajv');
-const Schema      = require('./resource-schema.json');
-
-/*
- * Configuration can be found @ https://github.com/epoberezkin/ajv/releases/tag/5.0.0
- */
-const ajv     = new Ajv({
-  meta: false, // optional, to prevent adding draft-06 meta-schema
-  extendRefs: true, // optional, current default is to 'fail', spec behaviour is to 'ignore'
-  unknownFormats: 'ignore',  // optional, current default is true (fail)
-  allErrors: true,
-  // ...
-});
-const metaSchema = require('ajv/lib/refs/json-schema-draft-04.json');
-ajv.addMetaSchema(metaSchema);
-ajv._opts.defaultMeta = metaSchema.id;
-// optional, using unversioned URI is out of spec, see https://github.com/json-schema-org/json-schema-spec/issues/216
-ajv._refs['http://json-schema.org/schema'] = 'http://json-schema.org/draft-04/schema';
-// Optionally you can also disable keywords defined in draft-06
-ajv.removeKeyword('propertyNames');
-ajv.removeKeyword('contains');
-ajv.removeKeyword('const');
+const api = require("@schul-cloud/schul-cloud-resources-api-v1");
 
 /*
  * Add hook
  */
 module.exports = function (options = {}) { // eslint-disable-line no-unused-vars
-  return commonHooks.validateSchema(Schema, ajv);
+  var schema = api.schemas.resource.getSchema();
+  return commonHooks.validateSchema(schema, api.ajv);
 };


### PR DESCRIPTION
#24, now the resources api module from https://github.com/schul-cloud/resources-api-v1/pull/91 is used.

Tests show a difference: 

```
E           schul_cloud_resources_api_v1.rest.ApiException: (401)
E           Reason: Unauthorized
E           HTTP response headers: HTTPHeaderDict({'Content-Length': '117', 'Access-Control-Allow-Origin': '*', 'X-Content-Type-Options': 'nosniff', 'Content-Type': 'application/json; charset=utf-8', 'X-Download-Options': 'noopen', 'X-Frame-Options': 'SAMEORIGIN', 'X-DNS-Prefetch-Control': 'off', 'Strict-Transport-Security': 'max-age=15552000; includeSubDomains', 'Connection': 'keep-alive', 'ETag': 'W/"75-MNfy66EiokrSlTh9xfxPZqTDNeU"', 'X-XSS-Protection': '1; mode=block', 'Allow': 'GET,POST,PUT,PATCH,DELETE', 'Date': 'Fri, 08 Sep 2017 17:46:14 GMT', 'Vary': 'Accept-Encoding'})
E           HTTP response body: {"name":"NotAuthenticated","message":"Could not authenticate","code":401,"className":"not-authenticated","errors":{}}
```