### PR TITLE
extend feathers-mongoose, so collection count is queried

### DIFF
--- a/src/services/resource/resource.service.js
+++ b/src/services/resource/resource.service.js
@@ -1,24 +1,42 @@
 // Initializes the `content` service on path `/content`
-const createService = require('feathers-mongoose');
+const { Service } = require('feathers-mongoose');
 const createModel = require('../../models/resource.model');
 const hooks = require('./resource.hooks');
 
+class MyService extends Service {
+    find(params) {
+        if(params.query.getCount){
+            delete params.query.getCount
+            return Promise.all([
+                this.Model.db.collections.resources.count(),
+                super.find(params)
+            ]).then(([ count, response ]) => {
+                console.dir(count)
+                response.count = count;
+                return response;
+            })
+        }
+
+        return super.find(params);
+    }
+}
+
 module.exports = function () {
-  const app = this;
-  const Model = createModel(app);
-  const paginate = app.get('paginate');
+    const app = this;
+    const Model = createModel(app);
+    const paginate = app.get('paginate');
 
-  const options = {
-    name: 'resources',
-    Model,
-    paginate
-  };
+    const options = {
+        name: 'resources',
+        Model,
+        paginate
+    };
 
-  // Initialize our service with any options it requires
-  app.use('/resources', createService(options));
+    // Initialize our service with any options it requires
+    app.use('/resources', new MyService(options));
 
-  // Get our initialized service so that we can register hooks and filters
-  const service = app.service('resources');
+    // Get our initialized service so that we can register hooks and filters
+    const service = app.service('resources');
 
-  service.hooks(hooks);
+    service.hooks(hooks);
 };


### PR DESCRIPTION
I'm not too convinced about this solution, but it works. do you see a better/simpler/more elegant way @kremer-io ? the content-Gesamtanzahl-von-Inhalten branch from the schulcloud client repo is required.